### PR TITLE
FIX: possible NPE when using ecj >3.13.0 with annotation processor

### DIFF
--- a/org.eclipse.jdt.core.tests.model/workspace/Compiler/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Compiler/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
@@ -22,6 +22,7 @@ public class PackageBinding extends Binding implements TypeConstants {
 	HashtableOfPackage knownPackages;
 protected PackageBinding() {
 	// for creating problem package
+	this.knownPackages = new HashtableOfPackage(1);	// normally 0	
 }
 public PackageBinding(char[][] compoundName, PackageBinding parent, LookupEnvironment environment) {
 	this.compoundName = compoundName;

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
@@ -45,6 +45,7 @@ public class PackageBinding extends Binding implements TypeConstants {
 
 protected PackageBinding() {
 	// for creating problem package
+	this.knownPackages = new HashtableOfPackage(1);	// normally 0
 }
 public PackageBinding(char[] topLevelPackageName, LookupEnvironment environment, ModuleBinding enclosingModule) {
 	this(new char[][] {topLevelPackageName}, null, environment, enclosingModule);
@@ -100,7 +101,7 @@ void addType(ReferenceBinding element) {
 	if (priorType != null && priorType.isUnresolvedType() && !element.isUnresolvedType()) {
 		((UnresolvedReferenceBinding) priorType).setResolvedType(element, this.environment);
 	}
-	if (this.environment.globalOptions.isAnnotationBasedNullAnalysisEnabled)
+	if (this.environment != null && this.environment.globalOptions.isAnnotationBasedNullAnalysisEnabled)
 		if (element.isAnnotationType() || element instanceof UnresolvedReferenceBinding) // unresolved types don't yet have the modifiers set
 			checkIfNullAnnotationType(element);
 


### PR DESCRIPTION
We are using the ecj/jdt.core in conjunction with annotation processors.

Our project won't compile in eclipse 4.7.3 - eclipse reports a NullPointerException (without stack-trace - was really hard to debug)


This PR fixes two NPEs that happened here. The behavour came with org.eclipse.jdt.core > 3.13.0
(version 3.13.0 / Eclipse 4.7.0 did not have that error)

*Possible cause of the error*
It seems that the annotation-processor needs more rounds, so in the first round not all dependent java files are generated, and eclipse creates a problemPackageBinding which is not fully initialized. Unfortunately, methods from the PropblemPackageBinding are accessed, which throw a NPE.

Stack traces

Eclipse build:
```
Thread [Worker-16] (Suspended (exception NullPointerException))	
	ProblemPackageBinding(PackageBinding).getPackage0(char[]) line: 171	
	LookupEnvironment.createPackage(char[][]) line: 1081	
	CompilationUnitScope.buildTypeBindings(AccessRestriction) line: 129	
	LookupEnvironment.buildTypeBindings(CompilationUnitDeclaration, AccessRestriction) line: 457	
	Compiler.internalBeginToCompile(ICompilationUnit[], int) line: 838	
	Compiler.processAnnotations() line: 954	
	Compiler.compile(ICompilationUnit[], boolean) line: 443	
	Compiler.compile(ICompilationUnit[]) line: 419	
	BatchImageBuilder(AbstractImageBuilder).compile(SourceFile[], SourceFile[], boolean) line: 372	
	BatchImageBuilder.compile(SourceFile[], SourceFile[], boolean) line: 187	
	BatchImageBuilder(AbstractImageBuilder).compile(SourceFile[]) line: 305	
	BatchImageBuilder.build() line: 61	
	JavaBuilder.buildAll() line: 256	
	JavaBuilder.build(int, Map, IProgressMonitor) line: 180	
	BuildManager$2.run() line: 735	
	SafeRunner.run(ISafeRunnable) line: 42	
	BuildManager.basicBuild(int, IncrementalProjectBuilder, Map<String,String>, MultiStatus, IProgressMonitor) line: 206	
	BuildManager.basicBuild(IBuildConfiguration, int, IBuildContext, ICommand[], MultiStatus, IProgressMonitor) line: 246	
	BuildManager$1.run() line: 301	
	SafeRunner.run(ISafeRunnable) line: 42	
	BuildManager.basicBuild(IBuildConfiguration, int, IBuildContext, MultiStatus, IProgressMonitor) line: 304	
	BuildManager.basicBuildLoop(IBuildConfiguration[], IBuildConfiguration[], int, MultiStatus, IProgressMonitor) line: 360	
	BuildManager.build(IBuildConfiguration[], IBuildConfiguration[], int, IProgressMonitor) line: 383	
	AutoBuildJob.doBuild(IProgressMonitor) line: 142	
	AutoBuildJob.run(IProgressMonitor) line: 232	
	Worker.run() line: 56	
```

Maven build:
```
Thread [main] (Suspended (exception NullPointerException))	
	ProblemPackageBinding(PackageBinding).addType(ReferenceBinding) line: 102	
	ClassScope.buildType(SourceTypeBinding, PackageBinding, AccessRestriction) line: 429	
	CompilationUnitScope.buildTypeBindings(AccessRestriction) line: 185	
	LookupEnvironment.buildTypeBindings(CompilationUnitDeclaration, AccessRestriction) line: 457	
	Compiler.internalBeginToCompile(ICompilationUnit[], int) line: 838	
	Compiler.processAnnotations() line: 954	
	Compiler.compile(ICompilationUnit[], boolean) line: 443	
	Compiler.compile(ICompilationUnit[]) line: 419	
	EclipseCompilerMain(Main).performCompilation() line: 4687	
	EclipseJavaCompiler.performCompile(CompilerConfiguration) line: 148	
	CompilerMojo(AbstractCompilerMojo).execute() line: 952	
	CompilerMojo.execute() line: 158	
	DefaultBuildPluginManager.executeMojo(MavenSession, MojoExecution) line: 134	
	MojoExecutor.execute(MavenSession, MojoExecution, ProjectIndex, DependencyContext) line: 207	
	MojoExecutor.execute(MavenSession, MojoExecution, ProjectIndex, DependencyContext, PhaseRecorder) line: 153	
	MojoExecutor.execute(MavenSession, List<MojoExecution>, ProjectIndex) line: 145	
	LifecycleModuleBuilder.buildProject(MavenSession, MavenSession, ReactorContext, MavenProject, TaskSegment) line: 116	
	LifecycleModuleBuilder.buildProject(MavenSession, ReactorContext, MavenProject, TaskSegment) line: 80	
	SingleThreadedBuilder.build(MavenSession, ReactorContext, ProjectBuildList, List<TaskSegment>, ReactorBuildStatus) line: 51	
	LifecycleStarter.execute(MavenSession) line: 128	
	DefaultMaven.doExecute(MavenExecutionRequest, MavenSession, MavenExecutionResult, DefaultRepositorySystemSession) line: 307	
	DefaultMaven.doExecute(MavenExecutionRequest) line: 193	
	DefaultMaven.execute(MavenExecutionRequest) line: 106	
	MavenCli.execute(CliRequest) line: 863	
	MavenCli.doMain(CliRequest) line: 288	
	MavenCli.main(String[], ClassWorld) line: 199	
	NativeMethodAccessorImpl.invoke0(Method, Object, Object[]) line: not available [native method]	
	NativeMethodAccessorImpl.invoke(Object, Object[]) line: 62	
	DelegatingMethodAccessorImpl.invoke(Object, Object[]) line: 43	
	Method.invoke(Object, Object...) line: 498	
	Launcher.launchEnhanced(String[]) line: 289	
	Launcher.launch(String[]) line: 229	
	Launcher.mainWithExitCode(String[]) line: 415	
	Launcher.main(String[]) line: 356	
```