### PR TITLE
Wrong section in the ecj man page

### DIFF
--- a/org.eclipse.jdt.core/scripts/ecj.1
+++ b/org.eclipse.jdt.core/scripts/ecj.1
@@ -1,4 +1,4 @@
-.TH ecj "13 March 2017"
+.TH ecj 1 "13 March 2017"
 .LP
 .SH NAME
 ecj \- the eclipse JDT Batch Compiler
@@ -19,7 +19,7 @@ Here is a summary of all the options, grouped by type.  Explanations are in the 
 .ul
 Module Options
 .sp
-.B --add-exports \--add-modules \--add-reads \--limit-modules \-p|--module-path \--module-source-path \ --processor-module-path \--system
+.B \--add-exports \--add-modules \--add-reads \--limit-modules \-p|--module-path \--module-source-path \ --processor-module-path \--system
 .sp
 .ul
 ClassPath Options


### PR DESCRIPTION
Hi,

Here is a trivial fix for a syntax issue in the ecj man page. Since R4_8 the section is missing in the header.